### PR TITLE
Change concurrency from 2 to a variable number based

### DIFF
--- a/heroku-node.sh
+++ b/heroku-node.sh
@@ -3,5 +3,5 @@ if [ -z $WEB_MEMORY ]
   then
     node "$@"
   else
-    node --max_old_space_size=$(($WEB_MEMORY / 2)) "$@"
+    node --max_old_space_size=$(($WEB_MEMORY / $WEB_CONCURRENCY)) "$@"
 fi


### PR DESCRIPTION
Heroku uses WEB_CONCURRENCY to provide an idea of how many dynos you have.  I think it would be a better choice then 2 for the divisor here.
